### PR TITLE
Spike/production logging fields

### DIFF
--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -54,8 +54,8 @@ module Logist
           { message: { method: method, path: path } }
         elsif msg.is_a?(String) && msg.split(' ')[0].match('User-Agent:') && msg.split("\n")[1].split(' ')[0].match('Accept:')
           splitted_msg = msg.split("\n")
-          user_agent = splitted_msg[0].split(' ')[1]
-          accept = splitted_msg[1].split(' ')[1]
+          user_agent = splitted_msg[0].split('"')[1]
+          accept = splitted_msg[1].split('"')[1]
           { message: { user_agent: user_agent, accept: accept } }
         else
           { message: msg }

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -47,6 +47,11 @@ module Logist
         elsif msg.is_a?(String) && msg.match(/Status [0-9]+/)
           status = msg.split(' ')[1]
           { message: { status: status } }
+        elsif msg.is_a?(String) && msg.split(' ').length == 2 && msg.split(' ')[0].match('GET')
+          splitted_msg = msg.split(' ')
+          method = splitted_msg[0]
+          path = splitted_msg[1]
+          { message: { method: method, path: path } }
         else
           { message: msg }
         end

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'logger'
 require 'rails'
@@ -7,11 +9,14 @@ module Logist
     class Json < ::Logger::Formatter
       attr_accessor :flat_json
 
-      def call(severity, timestamp, progname, raw_msg)
+      def call(severity, timestamp, _progname, raw_msg)
         msg = normalize_message(raw_msg)
         payload = { level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env }
 
-        if flat_json && msg.is_a?(Hash)
+        if msg.is_a?(String) && msg.match(/Status [0-9]+/)
+          status = msg.split(' ')[1]
+          payload.merge!(status: status)
+        elsif flat_json && msg.is_a?(Hash)
           payload.merge!(msg)
         else
           payload.merge!(message: msg)

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -10,11 +10,11 @@ module Logist
       attr_accessor :flat_json
 
       def call(severity, timestamp, _progname, raw_msg)
+        sev = severity.is_a?(String) && severity.match('FATAL') ? 'ERROR' : severity
+        tstamp = format_datetime(timestamp).strip
         msg = normalize_message(raw_msg)
 
-        sev = severity.is_a?(String) && severity.match('FATAL') ? 'ERROR' : severity
-
-        payload = { level: sev, timestamp: format_datetime(timestamp), environment: ::Rails.env }
+        payload = { level: sev, timestamp: tstamp, environment: ::Rails.env }
 
         if flat_json && msg.is_a?(Hash)
           payload.merge!(msg)

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -13,11 +13,11 @@ module Logist
         msg = normalize_message(raw_msg)
         payload = { level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env }
 
-        if msg.is_a?(String) && msg.match(/Status [0-9]+/)
-          status = msg.split(' ')[1]
-          payload.merge!(status: status)
-        elsif flat_json && msg.is_a?(Hash)
+        if flat_json && msg.is_a?(Hash)
           payload.merge!(msg)
+        elsif msg.is_a?(String) && msg.match(/Status [0-9]+/)
+          status = msg.split(' ')[1]
+          payload.merge!(message: { status: status })
         else
           payload.merge!(message: msg)
         end

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -11,7 +11,12 @@ module Logist
 
       def call(severity, timestamp, _progname, raw_msg)
         msg = normalize_message(raw_msg)
-        payload = { level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env }
+
+        sev = severity
+        if severity.is_a?(String) && severity.match('FATAL')
+          sev = 'ERROR'
+
+        payload = { level: sev, timestamp: format_datetime(timestamp), environment: ::Rails.env }
 
         if flat_json && msg.is_a?(Hash)
           payload.merge!(msg)

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -10,20 +10,13 @@ module Logist
       attr_accessor :flat_json
 
       def call(severity, timestamp, _progname, raw_msg)
-        sev = severity.is_a?(String) && severity.match('FATAL') ? 'ERROR' : severity
-        tstamp = format_datetime(timestamp).strip
-        msg = normalize_message(raw_msg)
+        sev = process_severity(severity)
+        tstamp = process_timestamp(timestamp)
 
         payload = { level: sev, timestamp: tstamp, environment: ::Rails.env }
 
-        if flat_json && msg.is_a?(Hash)
-          payload.merge!(msg)
-        elsif msg.is_a?(String) && msg.match(/Status [0-9]+/)
-          status = msg.split(' ')[1]
-          payload.merge!(message: { status: status })
-        else
-          payload.merge!(message: msg)
-        end
+        msg = process_message(raw_msg)
+        payload.merge!(msg)
 
         payload.to_json << "\n"
       end
@@ -36,6 +29,27 @@ module Logist
         JSON.parse(raw_msg)
       rescue JSON::ParserError
         raw_msg
+      end
+
+      def process_severity(severity)
+        severity.is_a?(String) && severity.match('FATAL') ? 'ERROR' : severity
+      end
+
+      def process_timestamp(timestamp)
+        format_datetime(timestamp).strip
+      end
+
+      def process_message(raw_msg)
+        msg = normalize_message(raw_msg)
+
+        if flat_json && msg.is_a?(Hash)
+          msg
+        elsif msg.is_a?(String) && msg.match(/Status [0-9]+/)
+          status = msg.split(' ')[1]
+          { message: { status: status } }
+        else
+          { message: msg }
+        end
       end
     end
   end

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -52,8 +52,8 @@ module Logist
           method = splitted_msg[0]
           path = splitted_msg[1]
           { message: { method: method, path: path } }
-        elsif msg.is_a?(String) && msg.split(' ')[0].match('User-Agent:') && msg.split('\n')[1].split(' ')[0].match('Accept:')
-          splitted_msg = msg.split('\n')
+        elsif msg.is_a?(String) && msg.split(' ')[0].match('User-Agent:') && msg.split("\n")[1].split(' ')[0].match('Accept:')
+          splitted_msg = msg.split("\n")
           user_agent = splitted_msg[0].split(' ')[1]
           accept = splitted_msg[1].split(' ')[1]
           { message: { user_agent: user_agent, accept: accept } }

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -52,6 +52,11 @@ module Logist
           method = splitted_msg[0]
           path = splitted_msg[1]
           { message: { method: method, path: path } }
+        elsif msg.is_a?(String) && msg.split(' ')[0].match('User-Agent:') && msg.split('\n')[1].split(' ')[0].match('Accept:')
+          splitted_msg = msg.split('\n')
+          user_agent = splitted_msg[0].split(' ')[1]
+          accept = splitted_msg[1].split(' ')[1]
+          { message: { user_agent: user_agent, accept: accept } }
         else
           { message: msg }
         end

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -12,9 +12,7 @@ module Logist
       def call(severity, timestamp, _progname, raw_msg)
         msg = normalize_message(raw_msg)
 
-        sev = severity
-        if severity.is_a?(String) && severity.match('FATAL')
-          sev = 'ERROR'
+        sev = severity.is_a?(String) && severity.match('FATAL') ? 'ERROR' : severity
 
         payload = { level: sev, timestamp: format_datetime(timestamp), environment: ::Rails.env }
 


### PR DESCRIPTION
As a result of suggestions from https://github.com/epimorphics/regulated-products/issues/209 and https://github.com/epimorphics/regulated-products-app/pull/68 I've forked the original Logist repo and made the following changes:
- status should now be a json field instead of plain text
- severity level "FATAL" changed to "ERROR"
- whitespace at the end of timestamps removed
- GET messages correctly structured as json now
- User Agent now also comes as a json field
...